### PR TITLE
Remove winmor, add vara

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,13 +149,13 @@
                 
                 <div class="carousel-inner owl-carousel">
                     
-                      <div class="item"> <blockquote><p>All major modes</p>winmor, ardop, pactor, ax25 and telnet.<a href=""></a></blockquote> </div>
+                      <div class="item"> <blockquote><p>All major modes</p>vara, ardop, pactor, ax25 and telnet.<a href=""></a></blockquote> </div>
                     
-                      <div class="item"> <blockquote><p>ARDOP</p>Pat has built in support for Winmor&#39;s succeessor.<a href=""></a></blockquote> </div>
+                      <div class="item"> <blockquote><p>ARDOP</p>Pat has built in support for this open HF protocol.<a href=""></a></blockquote> </div>
                     
                       <div class="item"> <blockquote><p>AX.25</p>Use an AX.25 TNC or the Linux kernel&#39;s implementation with a KISS TNC.<a href=""></a></blockquote> </div>
                     
-                      <div class="item"> <blockquote><p>WINMOR</p>The WINMOR TNC is supported. Winmor runs great on Wine.<a href=""></a></blockquote> </div>
+                      <div class="item"> <blockquote><p>VARA</p>The VARA TNC is supported. VARA runs great on Wine.<a href=""></a></blockquote> </div>
                     
                       <div class="item"> <blockquote><p>PACTOR</p>PACTOR modems (PTC-II and -III) can be used with Pat.<a href=""></a></blockquote> </div>
                     


### PR DESCRIPTION
Yes, VARA is still in beta. This is written forward-looking. This addresses https://github.com/la5nta/pat/issues/331#issuecomment-1102651365

I'm not sure what happened to the formatting; the only real changes are on 152-158. This is what the GitHub online editor did. I'll try to revert the superfluous diffs if you'd prefer.